### PR TITLE
Update yaml so it can be used with minikube server version v1.18.0

### DIFF
--- a/deploy/simple.yaml
+++ b/deploy/simple.yaml
@@ -86,7 +86,6 @@ data:
         port: 8080
         role: normal
         http: true
-        httpRootDir: /usr/share/qpid-dispatch/console/stand-alone
     }
 
     listener {

--- a/deploy/simple.yaml
+++ b/deploy/simple.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: myrouter
@@ -137,7 +137,7 @@ metadata:
   labels:
     application: myrouter
 ---
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -149,4 +149,5 @@ subjects:
 roleRef:
   kind: Role
   name: view
+  apiGroup: rbac.authorization.k8s.io
 


### PR DESCRIPTION
I am the following version of minikube

[gmurthy@localhost qdr-image]$ kubectl version
Client Version: version.Info{Major:"1", Minor:"10+", GitVersion:"v1.10.0+d4cacc0", GitCommit:"d4cacc0", GitTreeState:"clean", BuildDate:"2019-11-03T19:05:52Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.0", GitCommit:"9e991415386e4cf155a24b1da15becaa390438d8", GitTreeState:"clean", BuildDate:"2020-03-25T14:50:46Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}

The current simple of yaml gives the following error - 
[gmurthy@localhost deploy]$ kubectl apply -f simple.yaml
configmap/myrouter unchanged
service/myrouter unchanged
serviceaccount/myrouter unchanged
unable to recognize "simple.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
unable to recognize "simple.yaml": no matches for kind "RoleBinding" in version "v1"
[gmurthy@localhost deploy]$

We need a version of simple.yaml that works with the latest minikube?