### PR TITLE
Added targets to help building a snapshot image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PWD=$(shell pwd)
 
  # This is the latest version of the Qpid Dispatch Router
 DISPATCH_VERSION=1.12.0
+DISPATCH_SNAPSHOT_VERSION=1.13.0
 PROTON_VERSION=0.31.0
 PROTON_SOURCE_URL=http://archive.apache.org/dist/qpid/proton/${PROTON_VERSION}/qpid-proton-${PROTON_VERSION}.tar.gz
 ROUTER_SOURCE_URL=http://archive.apache.org/dist/qpid/dispatch/${DISPATCH_VERSION}/qpid-dispatch-${DISPATCH_VERSION}.tar.gz
@@ -23,6 +24,10 @@ build:
 	docker build -t qdrouterd-builder:${DOCKER_TAG_VAL} builder
 	docker run -ti -v $(PWD):/build:z -w /build qdrouterd-builder:${DOCKER_TAG_VAL} bash build_tarballs ${ROUTER_SOURCE_URL} ${PROTON_SOURCE_URL}
 
+build-snapshot:
+	docker build -t qdrouterd-builder:${DISPATCH_SNAPSHOT_VERSION}-snapshot builder
+	docker run -ti -v $(PWD):/build:z -w /build qdrouterd-builder:${DISPATCH_SNAPSHOT_VERSION}-snapshot bash build_tarballs_snapshot master master
+
 clean:
 	rm -rf proton_build proton_install qpid-dispatch.tar.gz qpid-dispatch-src qpid-proton.tar.gz qpid-proton-src staging build
 
@@ -33,7 +38,11 @@ buildimage:
 	docker build -t ${PROJECT_NAME}:latest .
 	docker tag ${PROJECT_NAME}:latest ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DOCKER_TAG_VAL}
 
-push: buildimage
+buildimage-snapshot: build-snapshot
+	docker build -t ${PROJECT_NAME}:snapshot .
+	docker tag ${PROJECT_NAME}:snapshot ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DISPATCH_SNAPSHOT_VERSION}-snapshot
+
+push-common:
 # DOCKER_USER and DOCKER_PASSWORD is useful in the CI environment.
 # Use the DOCKER_USER and DOCKER_PASSWORD if available
 # if not available, assume the user has already logged in
@@ -41,6 +50,10 @@ ifneq ($(strip $(DOCKER_USER)$(DOCKER_PASSWORD)),)
 	@docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} ${DOCKER_REGISTRY}
 endif
 
+push: buildimage push-common
 	docker push ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DOCKER_TAG_VAL}
+
+push-snapshot: buildimage-snapshot push-common
+	docker push ${DOCKER_REGISTRY}/${DOCKER_ORG}/${PROJECT_NAME}:${DISPATCH_SNAPSHOT_VERSION}-snapshot
 
 .PHONY: build buildimage cleanimage clean push

--- a/build_tarballs_snapshot
+++ b/build_tarballs_snapshot
@@ -1,0 +1,41 @@
+#!/usr/bin/bash
+
+
+do_patch () {
+    PATCH_DIR=$1
+    PATCH_SRC=$2
+    if [ -d "${PATCH_DIR}" ]
+    then
+        for patch in $(find ${PATCH_DIR} -type f -name "*.patch"); do
+            echo Applying patch ${patch}
+            patch -f -d "${PATCH_SRC}" -p1 < $patch
+        done;
+    fi
+}
+
+BASE=`dirname $0`
+ABS_BASE=`cd $BASE && pwd`
+WORKING=`pwd`
+OUTDIR=${3:-$ABS_BASE}
+
+QPID_DISPATCH_BRANCH="${1:-master}"
+QPID_PROTON_BRANCH="${2:-master}"
+
+mkdir -p qpid-dispatch-src qpid-proton-src build staging proton_build proton_install
+git clone -b ${QPID_PROTON_BRANCH} https://github.com/apache/qpid-proton.git qpid-proton-src
+git clone -b ${QPID_DISPATCH_BRANCH} https://github.com/apache/qpid-dispatch.git qpid-dispatch-src
+
+do_patch "patches/proton" qpid-proton-src
+do_patch "patches/dispatch" qpid-dispatch-src
+
+cd proton_build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_CPP=OFF -DBUILD_RUBY=OFF -DBUILD_GO=OFF -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_PYTHON=ON $WORKING/qpid-proton-src/ \
+    && make \
+    && make DESTDIR=$WORKING/proton_install install \
+    && tar -z -C $WORKING/proton_install -cf $OUTDIR/qpid-proton-image.tar.gz usr \
+    && make install
+cd $WORKING/build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_LIBWEBSOCKETS=ON -DBUILD_DOCS=OFF -DCONSOLE_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/usr $WORKING/qpid-dispatch-src/ \
+    && make  \
+    && make DESTDIR=$WORKING/staging/ install \
+    && tar -z -C $WORKING/staging/ -cf $OUTDIR/qpid-dispatch-image.tar.gz usr etc


### PR DESCRIPTION
@ganeshmurthy @grs not sure if adding the extra script `build_tarballs_snapshot` is a better
choice than modifying the existing `build_tarballs`, but anyway we can change it later if needed.
Once we have a mechanism to build a "snapshot" image built from qpid-dispatch / proton master,
next step would be to trigger Travis for this repository every time a PR is merged to master on qpid-dispatch.