### PR TITLE
Using default proton version from Makefile on nightly builds

### DIFF
--- a/travis/process_request
+++ b/travis/process_request
@@ -20,7 +20,9 @@
 if [ "$TRAVIS_EVENT_TYPE" != "cron" ]; then
     make
 else
-    make ROUTER_SOURCE_URL=http://github.com/apache/qpid-dispatch/archive/master.tar.gz PROTON_SOURCE_URL=http://github.com/apache/qpid-proton/archive/master.tar.gz
+    make ROUTER_SOURCE_URL=http://github.com/apache/qpid-dispatch/archive/master.tar.gz
+    #TODO Use master once issue is fixed on qpid-dispatch
+    #make ROUTER_SOURCE_URL=http://github.com/apache/qpid-dispatch/archive/master.tar.gz PROTON_SOURCE_URL=http://github.com/apache/qpid-proton/archive/master.tar.gz
 fi
 
 if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then


### PR DESCRIPTION
I noticed that nightly image is not working with Skupper. It is using Proton from master branch,
but when using master the inter-router connections are not being established. So I am proposing
this PR so nightly image uses the default PROTON_VERSION defined at Makefile.

I have already tested locally and it works.